### PR TITLE
Fix api base url and allow remember token login

### DIFF
--- a/src/tastytrade_sdk/api.py
+++ b/src/tastytrade_sdk/api.py
@@ -19,12 +19,25 @@ class RequestsSession:
     def __init__(self, config: Config):
         self.__base_url = f'https://{config.api_base_url}'
 
-    def login(self, login: str, password: str) -> None:
-        self.__session.headers['Authorization'] = self.request(
+    def login(self, login: str, password: str = None, remember_token: str = None, remember_me: bool = True) -> None:
+        data={'login': login}
+        if password:
+            data['password'] = password
+        else:
+            data['remember-token'] = remember_token
+        if remember_me:
+            data['remember-me'] = True
+
+        response = self.request(
             'POST',
             '/sessions',
-            data={'login': login, 'password': password}
-        )['data']['session-token']
+            json=data
+        )['data']
+
+        self.__session.headers['Authorization'] = response['session-token']
+        if remember_me:
+            # is Session.params the best place to store the remember token?
+            self.__session.params['remember-token'] = response['remember-token']
 
     def request(self, method: str, path: str, params: Optional[QueryParams] = tuple(),
                 data: Optional[dict] = None) -> Optional[dict]:

--- a/src/tastytrade_sdk/tastytrade.py
+++ b/src/tastytrade_sdk/tastytrade.py
@@ -10,10 +10,11 @@ class Tastytrade:
     The SDK's top-level class
     """
 
-    def __init__(self, api_base_url: str = 'api.tastytrade.com'):
+    def __init__(self, api_base_url: str = 'api.tastyworks.com'):
         """
         :param api_base_url: Optionally override the base URL used by the API
         (when using the sandbox environment, for e.g.)
+        cert url is 'api.cert.tastyworks.com'
         """
 
         def configure(binder):
@@ -21,11 +22,16 @@ class Tastytrade:
 
         self.__container = Injector(configure)
 
-    def login(self, login: str, password: str) -> 'Tastytrade':
+    def login(self, login: str, password: str = None, remember_token = None, remember_me: bool = True) -> 'Tastytrade':
         """
         Initialize a logged-in session
         """
-        self.__container.get(RequestsSession).login(login, password)
+        if not remember_token:
+            self.__container.get(RequestsSession).login(login, password=password, remember_me=remember_me)
+        elif not password:
+            self.__container.get(RequestsSession).login(login, remember_token=remember_token, remember_me=remember_me)
+        else:
+            print("Error: you must provide a password or remember token to log in")
         return self
 
     def logout(self) -> None:


### PR DESCRIPTION
The base URLs for production and cert are api.tastyworks.com and api.cert.tastyworks.com respectively.

Also, the login functions did not previously allow remember-me to be set true or login with a remember token. These changes would allow for users to take advantage of these features. Under these changes, the remember token, if requested, is stored in the params attribute of the requests.Session object in the RequestsSession class.