### PR TITLE
Add note about expired option symbols to README

### DIFF
--- a/docs/users/README.md
+++ b/docs/users/README.md
@@ -42,6 +42,7 @@ from tastytrade_sdk import Tastytrade
 tasty = Tastytrade().login(login='trader@email.com', password='password')
 
 # Subscribing to symbols across different instrument types
+# Please note: The option symbols here are expired. You need to subscribe to an unexpired symbol to receive quote data
 symbols = [
     'BTC/USD',
     'SPY',


### PR DESCRIPTION
Some users are getting confused when they'd copy-paste the example code and wouldn't receive quotes for expired options.