### PR TITLE
Lock to specific poetry version in github workflows so that CI/CD works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           python-version: '3.11'
       - uses: snok/install-poetry@v1
+        with:
+          version: '1.8.3'
       - run: poetry install
       - run: make lint
       - run: make test

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -11,6 +11,8 @@ jobs:
         with:
           python-version: '3.11'
       - uses: snok/install-poetry@v1
+        with:
+          version: '1.8.3'
       - run: poetry install
       - name: Publish snapshot
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           python-version: '3.11'
       - uses: snok/install-poetry@v1
+        with:
+          version: '1.8.3'
       - run: poetry install
       - name: build docs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           python-version: '3.11'
       - uses: snok/install-poetry@v1
+        with:
+          version: '1.8.3'
       - run: poetry install
       - run: make lint
       - run: make test

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -1,7 +1,7 @@
 # Developer Guide
 
 ## Requirements
-* Python 3.8+
+* [The correct python version](../../.python-version) installed on your system
   * [pyenv](https://github.com/pyenv/pyenv#installation) recommended for managing python versions
 * [Poetry](https://python-poetry.org/docs/) - for managing dependencies and virtual environments
 * The [hub CLI tool](https://github.com/github/hub#installation) - used by the `release` scripts to open PRs in github


### PR DESCRIPTION
Was seeing this failure:
https://github.com/tastytrade/tastytrade-sdk-python/actions/runs/13336770099/job/37253640406

Apparently Poetry released a new version recently that doesn't like the format of this project's pyproject.toml.

So explicitly specifying a Poetry version that works instead of implicitly pinning to latest.