### PR TITLE
fix for pip install build error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ pylint = "^2.17.4"
 pylint-quotes = "^0.2.3"
 pdoc = "^14.0.0"
 
+[project]
+name = "tastytrade-sdk"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change adds project metadata, specifically the project name, to the configuration file.

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R33-R35): Added the project name under the `[project]` section.

fixes: https://github.com/tastytrade/tastytrade-sdk-python/issues/32